### PR TITLE
Add leilab-calendar.json for reservation system

### DIFF
--- a/domains/leilab-calendar.json
+++ b/domains/leilab-calendar.json
@@ -1,0 +1,11 @@
+{
+  "description": "Lei Lab Computer Reservation System - Tokyo Institute of Technology",
+  "repo": "https://github.com/Shirakawa11111/lab-calendar",
+  "owner": {
+    "username": "Shirakawa11111",
+    "email": "bo.j.aa@m.titech.ac.jp"
+  },
+  "record": {
+    "CNAME": "shirakawa11111.github.io"
+  }
+}


### PR DESCRIPTION
  Domain: leilab-calendar.is-a.dev
  Purpose: Laboratory computer reservation system for academic use at Tokyo Tech